### PR TITLE
Update QA env to use the service domain

### DIFF
--- a/.github/workflows/smoke-tests-qa.yml
+++ b/.github/workflows/smoke-tests-qa.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           CYPRESS_ENVIRONMENT: QA
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          CYPRESS_BASE_URL: https://qa.apply-for-teacher-training.education.gov.uk
+          CYPRESS_BASE_URL: https://qa.apply-for-teacher-training.service.gov.uk
           CYPRESS_CANDIDATE_TEST_EMAIL: ${{ secrets.CANDIDATE_TEST_EMAIL }}
           CYPRESS_GOVUK_NOTIFY_API_KEY: ${{ secrets.GOVUK_NOTIFY_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
-  "baseUrl": "https://qa.apply-for-teacher-training.education.gov.uk",
+  "baseUrl": "https://qa.apply-for-teacher-training.service.gov.uk",
   "projectId": "tqfe7m"
 }


### PR DESCRIPTION
Currently we go to the education domain. Then the email with the sign in links takes you to the service domain. This causes the tests to fail because a run can only occur on one superdomain.