### PR TITLE
Add explanation for env vars to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,18 @@ Install dependencies:
 yarn
 ```
 
-Create a `cypress.env.json` and replace the necessary variables:
+Create a `cypress.env.json` from the example:
 
 ```bash
 cp cypress.env.json.example cypress.env.json
 vim cypress.env.json
 ```
+
+You'll need to replace the following variables:
+
+| Name                 | Explanation                                                                                                                                  |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| GOVUK_NOTIFY_API_KEY | A Notify API key. Needs to be a Live one because we need to check the email logs for live environments, such as QA or Staging or Production. |
 
 Run cypress end to end tests:
 


### PR DESCRIPTION
We need a live `GOVUK_NOTIFY_API_KEY` but this isn't explained anywhere.