### PR TITLE
Update wording for post sign-in message

### DIFF
--- a/cypress/integration/candidate.spec.js
+++ b/cypress/integration/candidate.spec.js
@@ -83,14 +83,14 @@ const thenIAmToldToCheckMyEmail = () => {
 
 const whenIClickTheLinkInMyEmail = () => {
   cy.task("getSignInLinkFor", { emailAddress: CANDIDATE_EMAIL }).then(
-    (signInLink) => {
+    signInLink => {
       cy.visit(signInLink);
     }
   );
 };
 
 const thenIShouldBeSignedInSuccessfully = () => {
-  cy.contains("We suggest you choose a course first");
+  cy.contains("Choose a course first");
 };
 
 const isBetweenCycles = () => {


### PR DESCRIPTION
It's now "Choose a course first" instead of "We suggest..."