### PR TITLE
Fix notifications-node-client breaking change

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -41,7 +41,7 @@ module.exports = (on, config) => {
 
   const getNotifyEmailFor = async (emailAddress, retries = 3) => {
     const response = await notifyClient.getNotifications("email");
-    const notifications = response.toJSON().body.notifications;
+    const notifications = response.data.notifications;
     let notifyEmail = notifications.find(signInEmailFor(emailAddress));
 
     if (!notifyEmail && retries > 0) {


### PR DESCRIPTION
From the changelog:

> The response object returned by a successful API call is now in the form of an axios response. This has a different interface to a request response. For example:
> 
> - response.body becomes response.data
> - response.statusCode becomes response.status

Tested locally, it fixes the current breaking builds on Sandbox.