### PR TITLE
Enable component tests and raise coverage to `serious`

### DIFF
--- a/cypress/integration/candidate.spec.js
+++ b/cypress/integration/candidate.spec.js
@@ -94,7 +94,7 @@ const thenIShouldBeSignedInSuccessfully = () => {
 };
 
 const isBetweenCycles = () => {
-  const endOfCycle = +new Date(2020, 7, 24);
+  const endOfCycle = +new Date(2020, 7, 25);
   const startOfNewCycle = +new Date(2020, 9, 13);
   const currentTime = +new Date();
 

--- a/cypress/integration/components.spec.js
+++ b/cypress/integration/components.spec.js
@@ -3,7 +3,7 @@ const ENVIRONMENT = Cypress.env("ENVIRONMENT") || "Unknown";
 describe(`[${ENVIRONMENT}] Components`, () => {
   it("are accessible", () => {
     givenIAmOnTheComponentReviewPage();
-    // thenEachComponentShouldBeAccessible();
+    thenEachComponentShouldBeAccessible();
   });
 });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -45,9 +45,11 @@ function terminalLog(violations) {
 Cypress.Commands.add("runAxe", () => {
   cy.injectAxe();
   cy.checkA11y(
-    null,
     {
-      includedImpacts: ["critical"],
+      exclude: [["#navigation", "ul"]],
+    },
+    {
+      includedImpacts: ["critical", "serious"],
     },
     terminalLog
   );


### PR DESCRIPTION
## Context

We want to increase the scope of accessibility testing we do using Cypress to pick up any issues as soon as they are deployed to `qa`. To achieve this we need to fix any existing errors.

https://github.com/DFE-Digital/apply-for-teacher-training/pull/2959
https://github.com/DFE-Digital/apply-for-teacher-training/pull/2963

Once these are merged this PR will enable more extensive accessibility tests.

## Changes proposed in this pull request

- Increase Axe error level to `serious` (was previously set to only pick up `critical` issues)
- Enable tests on component previews
- Suppress error on `nav` element on candidate interface

## Guidance to review

- per commit

## Link to Trello card

https://trello.com/c/ALvwnGc6/1844-include-serious-accessibility-issues-in-axe-tests
