### PR TITLE
Remove steps to fill eligibility form in signup test

### DIFF
--- a/cypress/integration/candidate.spec.js
+++ b/cypress/integration/candidate.spec.js
@@ -7,12 +7,9 @@ describe(`[${ENVIRONMENT}] Candidate`, () => {
     andItIsAccessible();
     whenIClickOnStartNow();
     whenIChooseToCreateAnAccount();
-    if (isBetweenCycles() && !isSandbox())
+    if (isBetweenCycles() && !isSandbox()) {
       return thenIShouldBeToldThatApplicationsAreClosed();
-    else thenICanCheckMyEligibility();
-
-    whenICheckThatIAmEligible();
-    andIClickContinue();
+    }
     thenICanCreateAnAccount();
 
     whenITypeInMyEmail();
@@ -42,19 +39,6 @@ const whenIClickOnStartNow = () => {
 const whenIChooseToCreateAnAccount = () => {
   cy.contains("No, I need to create an account").click();
   cy.contains("Continue").click();
-};
-
-const thenICanCheckMyEligibility = () => {
-  cy.contains("Check we’re ready for you to use this service");
-};
-
-const whenICheckThatIAmEligible = () => {
-  cy.get(
-    "#candidate-interface-eligibility-form-eligible-citizen-yes-field"
-  ).click();
-  cy.get(
-    "#candidate-interface-eligibility-form-eligible-qualifications-yes-field"
-  ).click();
 };
 
 const andIClickContinue = () => {

--- a/cypress/integration/candidate.spec.js
+++ b/cypress/integration/candidate.spec.js
@@ -7,7 +7,7 @@ describe(`[${ENVIRONMENT}] Candidate`, () => {
     andItIsAccessible();
     whenIClickOnStartNow();
     whenIChooseToCreateAnAccount();
-    if (isBetweenCycles() && !isSandbox()) {
+    if (isBetweenCycles()) {
       return thenIShouldBeToldThatApplicationsAreClosed();
     }
     thenICanCreateAnAccount();
@@ -74,7 +74,7 @@ const whenIClickTheLinkInMyEmail = () => {
 };
 
 const thenIShouldBeSignedInSuccessfully = () => {
-  cy.contains("Choose a course first");
+  cy.contains("Do you want to continue applying?");
 };
 
 const isBetweenCycles = () => {


### PR DESCRIPTION
## Context
The eligibility form has gone now that we've activated the `international_personal_details` feature flag. So now that the new recruitment cycle has opened and we are attempting to test the full sign-up process we are seeing errors despite the system working as it should.

https://dashboard.cypress.io/projects/tqfe7m/runs/1197/test-results/bbccc0f9-aae2-466e-9a04-9248ec1ea089

## Changes proposed in this pull request
Just remove the steps.

## Guidance to review
Assumption: We are not going to deactivate the feature flag.

