### PR TITLE
Temporarily disable component tests

### DIFF
--- a/cypress/integration/components.spec.js
+++ b/cypress/integration/components.spec.js
@@ -1,6 +1,6 @@
 const ENVIRONMENT = Cypress.env("ENVIRONMENT") || "Unknown";
 
-describe(`[${ENVIRONMENT}] Components`, () => {
+describe.skip(`[${ENVIRONMENT}] Components`, () => {
   it("are accessible", () => {
     givenIAmOnTheComponentReviewPage();
     thenEachComponentShouldBeAccessible();


### PR DESCRIPTION
The route is broken on QA and is 404ing. It's unclear why. We should disable the tests until we figure it out.