### PR TITLE
Enable accessibility test on the candidate main journey

### DIFF
--- a/cypress/integration/candidate.spec.js
+++ b/cypress/integration/candidate.spec.js
@@ -4,7 +4,7 @@ const CANDIDATE_EMAIL = Cypress.env("CANDIDATE_TEST_EMAIL");
 describe(`[${ENVIRONMENT}] Candidate`, () => {
   it("can sign up successfully", () => {
     givenIAmOnTheHomePage();
-    // andItIsAccessible();
+    andItIsAccessible();
     whenIChooseToCreateAnAccount();
     if (isBetweenCycles()) {
       return thenIShouldBeToldThatApplicationsAreClosed();

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -44,6 +44,15 @@ function terminalLog(violations) {
 
 Cypress.Commands.add("runAxe", () => {
   cy.injectAxe();
+  cy.configureAxe({
+    // https://github.com/alphagov/govuk-frontend/issues/979
+    // This issue is present on forms with conditional checkboxes, such as the
+    // candidate sign up form. Axe will complain that these inputs shouldn't
+    // have an aria-expanded attribute. However, the design system currently
+    // still uses this attribute, as it does help on devices such as NVDA.
+    // Disable the rule to prevent Axe from bringing it up.
+    rules: [{ id: 'aria-allowed-attr', enabled: false }],
+  })
   cy.checkA11y(
     {
       exclude: [["#navigation", "ul"]],


### PR DESCRIPTION
We had to disable this when we moved the Axe check to the account page instead of the home page.