### PR TITLE
Re-enable component tests

### DIFF
--- a/cypress/integration/components.spec.js
+++ b/cypress/integration/components.spec.js
@@ -1,6 +1,6 @@
 const ENVIRONMENT = Cypress.env("ENVIRONMENT") || "Unknown";
 
-describe.skip(`[${ENVIRONMENT}] Components`, () => {
+describe(`[${ENVIRONMENT}] Components`, () => {
   it("are accessible", () => {
     givenIAmOnTheComponentReviewPage();
     thenEachComponentShouldBeAccessible();


### PR DESCRIPTION
Now that the route is fixed https://github.com/DFE-Digital/apply-for-teacher-training/pull/3207, we can turn this test back on.