### PR TITLE
Revert "Update signed in content"

### DIFF
--- a/cypress/integration/candidate.spec.js
+++ b/cypress/integration/candidate.spec.js
@@ -1,7 +1,7 @@
 const ENVIRONMENT = Cypress.env("ENVIRONMENT") || "Unknown";
 const CANDIDATE_EMAIL = Cypress.env("CANDIDATE_TEST_EMAIL");
 
-describe(`[${ENVIRONMENT}] Candidate`, () => {
+describe.skip(`[${ENVIRONMENT}] Candidate`, () => {
   it("can sign up successfully", () => {
     givenIAmOnTheHomePage();
     andItIsAccessible();

--- a/cypress/integration/candidate.spec.js
+++ b/cypress/integration/candidate.spec.js
@@ -69,7 +69,7 @@ const whenIClickTheLinkInMyEmail = () => {
 };
 
 const thenIShouldBeSignedInSuccessfully = () => {
-  cy.contains("Your application");
+  cy.contains("Do you want to continue applying?");
 };
 
 const isBetweenCycles = () => {


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-teacher-training-tests#28

Turns out this content is only different on QA. Will push a follow-up commit to `.skip` the test while I investigate.