### PR TITLE
Update signed in content

### DIFF
--- a/cypress/integration/candidate.spec.js
+++ b/cypress/integration/candidate.spec.js
@@ -1,7 +1,7 @@
 const ENVIRONMENT = Cypress.env("ENVIRONMENT") || "Unknown";
 const CANDIDATE_EMAIL = Cypress.env("CANDIDATE_TEST_EMAIL");
 
-describe.skip(`[${ENVIRONMENT}] Candidate`, () => {
+describe(`[${ENVIRONMENT}] Candidate`, () => {
   it("can sign up successfully", () => {
     givenIAmOnTheHomePage();
     andItIsAccessible();
@@ -69,7 +69,7 @@ const whenIClickTheLinkInMyEmail = () => {
 };
 
 const thenIShouldBeSignedInSuccessfully = () => {
-  cy.contains("Do you want to continue applying?");
+  cy.contains("Sign out");
 };
 
 const isBetweenCycles = () => {


### PR DESCRIPTION
Previously https://github.com/DFE-Digital/apply-for-teacher-training-tests/pull/28

The previous fix failed, because it turns out the reason that QA is now reporting different content compared to Staging/Production is because the test account was likely touched by a support user and put into a state where it's past the "Do you want to Apply Again?" banner. The other environments are not in this situation.

To address this, it's easiest to check if sign in works correctly by checking if "Sign out" is present in the page.