### PR TITLE
Update cypress-axe to 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "cypress": "^4.12.1",
-    "cypress-axe": "^0.8.1",
+    "cypress-axe": "^0.10.0",
     "notifications-node-client": "^5.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -331,10 +331,10 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cypress-axe@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/cypress-axe/-/cypress-axe-0.8.1.tgz#ddb37dca6570c0642dda2388daf678e83b3e8d3f"
-  integrity sha512-hX48+r5n7Ns7CHkn601Ag0JiCG1vby5+g7QhlP8X+mkiVYpTLpXAPiiaKFj9QTTCdZSI5+0UqwIxA+ShTsr5tA==
+cypress-axe@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/cypress-axe/-/cypress-axe-0.10.0.tgz#fc3536d7da47ff90f9665cf8fbf8e820e09202b9"
+  integrity sha512-McmUZl34tD+DFEEvQYsmszMahsSEKYoNb9lJpIUHHhmcFPEjStCFFxmCmWkfRBh/FkWJ+8WoCHkcl663+w3E/w==
 
 cypress@^4.12.1:
   version "4.12.1"


### PR DESCRIPTION
This project has changed ownership and it looks like Dependabot can't automatically update it.