### PR TITLE
Update smoke-tests.yml

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v1
         with:
-          record: true
           spec: cypress/integration/candidate.spec.js
         env:
           CYPRESS_ENVIRONMENT: ${{ matrix.environment }}


### PR DESCRIPTION
Remove `record` flag, because we don't have a cypress dashboard env var anymore.