### PR TITLE
Revert "Output to #twd_apply_test while testing new GitHub action"

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -55,7 +55,7 @@ jobs:
         if: failure()
         uses: rtCamp/action-slack-notify@master
         env:
-          SLACK_CHANNEL: 'twd_apply_test'
+          SLACK_CHANNEL: 'twd_apply_tech'
           SLACK_COLOR: '#c0392b'
           SLACK_ICON_EMOJI: ':sad-beaver:'
           SLACK_MESSAGE: 'Smoke tests failed to run :sadparrot:'


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-teacher-training-tests#34

Looks like it works well now, so we can revert this.